### PR TITLE
fix: change chain name to be a slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Before you begin, ensure you have the following installed on your system:
 
     ```json
     {
-        "chainName": "ethereum",
+        "chainNames": ["ethereum"],
         "chainType": "evm",
         "methods": [
             {
@@ -97,7 +97,7 @@ Before you begin, ensure you have the following installed on your system:
             - **`Solana`**: the solana go's standard [CommitmentType](https://github.com/gagliardetto/solana-go/blob/main/rpc/types.go#L431)
 
     - **Explanation of Fields**:
-        - **`chainName`**: Name of the chain of the config file, this field is just for trackability purposes it is not used in this repo
+        - **`chainNames`**: Name of the chains of the config file, this field is just for trackability purposes it is not used in this repo
         - **`chainType`**: Chain type of the chain of the config file, this field is a enum specified on `ChainType` in the `custom-rpc-methods/custom_rpc_methods.go` file
         - **`customMethod`**: The method name used to retrieve data along with the getter struct (block number in the case of EVM).
         - **`originalMethod`**: The original method name without the getter struct support.

--- a/custom-rpc-methods/custom_rpc_methods.go
+++ b/custom-rpc-methods/custom_rpc_methods.go
@@ -37,9 +37,9 @@ type Method struct {
 }
 
 type MethodsConfig struct {
-	ChainName string    `json:"chainName"`
-	ChainType ChainType `json:"chainType"`
-	Methods   []Method  `json:"methods"`
+	ChainNames []string  `json:"chainNames"`
+	ChainType  ChainType `json:"chainType"`
+	Methods    []Method  `json:"methods"`
 }
 
 // this structure is needed bc you can't return directly a generic in a non generic func

--- a/supported-chains/blast.json
+++ b/supported-chains/blast.json
@@ -1,5 +1,5 @@
 {
-  "chainName": "blast",
+  "chainNames": ["blast"],
   "chainType": "evm",
     "methods": [
       {

--- a/supported-chains/erigon.json
+++ b/supported-chains/erigon.json
@@ -1,5 +1,5 @@
 {
-  "chainName": "erigon",
+  "chainNames": ["erigon"],
   "chainType": "evm",
     "methods": [
       {

--- a/supported-chains/ethereum.json
+++ b/supported-chains/ethereum.json
@@ -1,5 +1,5 @@
 {
-  "chainName": "ethereum",
+  "chainNames": ["ethereum", "arbitrum", "optimism"],
   "chainType": "evm",
   "methods": [
     {

--- a/supported-chains/polygon-bor.json
+++ b/supported-chains/polygon-bor.json
@@ -1,5 +1,5 @@
 {
-  "chainName": "polygon-bor",
+  "chainNames": ["polygon-bor"],
   "chainType": "evm",
     "methods": [
       {

--- a/supported-chains/solana.json
+++ b/supported-chains/solana.json
@@ -1,5 +1,5 @@
 {
-    "chainName": "solana",
+    "chainNames": ["solana"],
     "chainType": "solana",
       "methods": [
         {


### PR DESCRIPTION
Changes chain name field to be a slice to note that multiple chains can have the same custom methods (mostly for the EVM use case)